### PR TITLE
Fix default_scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Or with options:
 
     /auth/strava?scope=view_private,write
 
-By default the requested scope is "public". Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
+By default the requested scope is "read". Scope can be configured either explicitly as a `scope` query value on the request path or in your configuration:
 
 ```elixir
 config :ueberauth, Ueberauth,

--- a/lib/ueberauth/strategy/strava.ex
+++ b/lib/ueberauth/strategy/strava.ex
@@ -3,7 +3,7 @@ defmodule Ueberauth.Strategy.Strava do
   Strava Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, default_scope: "public"
+  use Ueberauth.Strategy, default_scope: "read"
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials


### PR DESCRIPTION
The default scope "public" no longer works; it's not on the list of scopes in the [Strava authentication docs](https://developers.strava.com/docs/authentication/). The "read" scope seems to be the most closely aligned with "public".